### PR TITLE
Replace `be` with `become`

### DIFF
--- a/rust.xml
+++ b/rust.xml
@@ -18,7 +18,7 @@
 	<list name="reserved">
 		<item> abstract </item>
 		<item> alignof </item>
-		<item> be </item>
+		<item> become </item>
 		<item> do </item>
 		<item> final </item>
 		<item> offsetof </item>


### PR DESCRIPTION
The reserved keyword `be` has been replaced with `become` by
rust-lang/rust#21918.
