### PR TITLE
Deprecate repository and document new upstream location.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,23 @@
-To install this highlighting file run:
+Development of the Rust syntax highlighting file for Kate and
+compatible editors has moved to the KTextEditor library (part
+of KDE Frameworks, and used by Kate and others) on kde.org.
 
-```
-# Clone
-git clone https://github.com/rust-lang/kate-config.git`
 
-# The following differs between Kate 4.x and 5.x, see below:
+To get it, grab a KDE Frameworks / KTextEditor release v5.11.0
+or higher from https://download.kde.org or your distro, or:
 
-# For Kate 4.x:
-mkdir --parents ~/.kde/share/apps/katepart/syntax
-cp kate-config/rust.xml ~/.kde/share/apps/katepart/syntax
+- Clone git://anongit.kde.org/ktexteditor.git
 
-# For Kate 5.x:
-mkdir --parents ~/.local/share/apps/katepart5/syntax
-cp kate-config/rust.xml ~/.local/share/apps/katepart5/syntax
-```
+- Browse ktexteditor.git here:
+  http://quickgit.kde.org/?p=ktexteditor.git
 
-Then from Kate, open a Rust file. If Rust highlighting
-isn't enabled, enable this setting in the menus:
+rust.xml is in src/syntax/data.
 
-Tools -> Highlighting -> Sources -> Rust
 
-## License
+If you'd like to contribute a patch, use one of:
 
-Rust is primarily distributed under the terms of both the MIT license
-and the Apache License (Version 2.0), with portions covered by various
-BSD-like licenses.
+- https://git.reviewboard.kde.org/ (repository ktexteditor)
+- https://bugs.kde.org (product frameworks-ktexteditor)
 
-See [LICENSE-APACHE](LICENSE-APACHE), [LICENSE-MIT](LICENSE-MIT), and [COPYRIGHT](COPYRIGHT) for details.
+The license is MIT as per the Rust license, and preserved in
+the file.


### PR DESCRIPTION
The next release of KDE's editor Kate will bundle a Rust code completion plugin. Between this development and the Rust 1.0 release, it starts to make sense to bundle the syntax highlighting file with it as well. Further, to avoid having to sync two copies, it makes sense to relocate development and maintenance to the KDE repo ... or so I've hashed out in conversation with @brson yesterday :-)

Notes:
- Development of the file will move into the KTextEditor library, which is a dependency of Kate (and other editor control users, e.g. KDevelop) and a part of KDE's Frameworks library set. Frameworks does monthly releases, i.e. keeping up with the Rust release cadence isn't a huge problem when the file needs to be augmented.
- There is no need to re-license; the file stays MIT.
- The entire history of this repo has been replayed into ktexteditor.git, preserving the record of the Rust community's work should this repo be removed in the future: http://quickgit.kde.org/?p=ktexteditor.git&a=log
- External contributions will remain easy. 
- This will deliver Rust syntax highlighting to lots of Kate users via distro packages.
- There are other editors using Kate's syntax highlighting file format, in particular Qt Creator. Creator users are used to installing or getting files from KDE, though, as most existing files are developed and released there (see http://quickgit.kde.org/?p=ktexteditor.git&a=tree&f=src%2Fsyntax%2Fdata).
